### PR TITLE
Important update

### DIFF
--- a/files/files_final_version/external_inputs.py
+++ b/files/files_final_version/external_inputs.py
@@ -13,7 +13,7 @@ import pandas as pd
 from inputs_parameters import *
 import sys
 import os
-#sys.path.append("/home/jaime/Desktop/hippocampus/files")
+sys.path.append('/home/dimitrios/Neurons/CA1model/final_files/')
 import file_management
 
 input1 = int(sys.argv[1]) # select the input category: baseline, ec2_faster_1, etc
@@ -82,7 +82,7 @@ def dg_burst_inputs(sead,time_simulation, time_initial, sigma, period, ncells, p
     return sead, idv, spikes
 
 # inputs path (do not forget to modify)
-inputs_path = os.path.join( "/home/jaime/Desktop/hippocampus/external_inputs/", input_type)
+inputs_path = os.path.join( "/home/dimitrios/Neurons/CA1model/ECfasterCA3/external_inputs", input_type)
 
 ncells_per_label = [ inputs_params[input_type][lb]["ncells"] for lb in labels ]
 ncells_total = np.sum(ncells_per_label)

--- a/files/files_final_version/functions.py
+++ b/files/files_final_version/functions.py
@@ -30,7 +30,7 @@ def process_syn_data( data_unified ): #syncurrents
     data = {}
     for key in keys:
         aux = []
-        for i in range(len(data_unified[key])):
+        for i in data_unified[key][0]:
             aux.append(data_unified[key][0][i])
         data[f"i{key}_mean"] = np.mean(aux,axis=0)
         data[f"i{key}_std"]  = np.std(aux,axis=0)

--- a/files/files_final_version/inputs_parameters.py
+++ b/files/files_final_version/inputs_parameters.py
@@ -4,7 +4,7 @@
 time_initial = 50
 theta_rythm = 125 
 
-inputs = ["baseline","ec2_faster_1","ec2_faster_2","ec3_faster_1","ec3_faster_2"]
+inputs = ["baseline","ec2_faster_1","ec2_faster_2","ec3_faster_1","ec3_faster_2","ec_slower"]
 labels = ['sep_180', 'sep_360', 'ec2_180', 'ec2_360', 'ec3_180','ec3_360','dg_regular', 'dg_burst']
 params = ["time_start", "ncells", "sigma","period"]
           
@@ -143,6 +143,26 @@ inputs_params["ec3_faster_2"]["dg_burst"]["period"]   = theta_rythm
 
 ##########################################################################################
 
+# EC with lower  frequency -0.25 Hz
+inputs_params["ec_slower"]["sep_180"]["time_start"]    = time_initial+theta_rythm/2.0
+inputs_params["ec_slower"]["sep_360"]["time_start"]    = time_initial
+inputs_params["ec_slower"]["ec2_180"]["time_start"]    = time_initial+theta_rythm/2.0
+inputs_params["ec_slower"]["ec2_360"]["time_start"]    = time_initial
+inputs_params["ec_slower"]["ec3_180"]["time_start"]    = time_initial+theta_rythm/2.0
+inputs_params["ec_slower"]["ec3_360"]["time_start"]    = time_initial
+inputs_params["ec_slower"]["dg_regular"]["time_start"] = time_initial+0.375*theta_rythm
+inputs_params["ec_slower"]["dg_burst"]["time_start"]   = time_initial+0.125*theta_rythm
+
+inputs_params["ec_slower"]["sep_180"]["period"]    = theta_rythm
+inputs_params["ec_slower"]["sep_360"]["period"]    = theta_rythm
+inputs_params["ec_slower"]["ec2_180"]["period"]    = 129.0
+inputs_params["ec_slower"]["ec2_360"]["period"]    = 129.0
+inputs_params["ec_slower"]["ec3_180"]["period"]    = 129.0
+inputs_params["ec_slower"]["ec3_360"]["period"]    = 129.0
+inputs_params["ec_slower"]["dg_regular"]["period"] = theta_rythm
+inputs_params["ec_slower"]["dg_burst"]["period"]   = theta_rythm
+
+#############################################################################################
 # EC2 shifted 
 inputs_ec2 = [f"ec2_shifted_{i}" for i in range(1,len(phase_shift)+1)]
 for i,keys in enumerate(inputs_ec2):
@@ -186,6 +206,8 @@ for i,keys in enumerate(inputs_dg):
     inputs_params[keys]["dg_regular"]["period"] = theta_rythm
     inputs_params[keys]["dg_burst"]["period"]   = theta_rythm
 ##########################################################################################
+
+
 
 # future: DG regular and burst
 

--- a/files/files_final_version/network_hippocampus_ca1.py
+++ b/files/files_final_version/network_hippocampus_ca1.py
@@ -499,6 +499,7 @@ class Network:
         key = keys[-1]
         file = f"external_inputs_{key}.lzma"
         data = file_management.load_lzma(os.path.join(self.inputs_folder,file))
+        print(os.path.join(self.inputs_folder,file),self.external_inputs_iseed,self.external_inputs_ibseed)
         w = (data["iseed"]==self.external_inputs_iseed) & (data["ibseed"]==self.external_inputs_ibseed)
         x = np.array( data["tvec"][w].values )
         y = np.array( data["idvec"][w].values )

--- a/files/files_final_version/neurons.py
+++ b/files/files_final_version/neurons.py
@@ -57,6 +57,7 @@ class Cell:
         self.calc_area()
 
         self.spike_detector = h.NetCon(self.soma(0.5)._ref_v, None, sec=self.soma)
+        self.spike_detector.threshold = 0.0
         self.spike_times = h.Vector()
         self.spike_detector.record(self.spike_times)
         self.nc  = [] # connection between population src-> this cell
@@ -316,47 +317,52 @@ class PyrAdr_CA3(Cell):
 
     def set_synapses(self):
         # external noise 
-        self.somaAMPA_noise    = Synapse(sect=self.soma, loc=0.5, tau1=0.05, tau2=5.3,  e=0)   
-        self.somaGABA_noise    = Synapse(sect=self.soma, loc=0.5, tau1=0.07, tau2=9.1,  e=-80) 
-        self.Adend3AMPA_noise  = Synapse(sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3,  e=0)   
-        self.Adend3GABA_noise  = Synapse(sect=self.Adend3, loc=0.5, tau1=0.07, tau2=9.1,  e=-80) 
+        self.somaAMPA_noise    = Synapse( sect=self.soma,   loc=0.3, tau1=0.05, tau2=5.3,  e=0 )   
+        self.somaGABA_noise    = Synapse( sect=self.soma,   loc=0.7, tau1=0.07, tau2=9.1,  e=-80 ) 
+        self.Adend3AMPA_noise  = Synapse( sect=self.Adend3, loc=0.3, tau1=0.05, tau2=5.3,  e=0 )   
+        self.Adend3GABA_noise  = Synapse( sect=self.Adend3, loc=0.7, tau1=0.07, tau2=9.1,  e=-80 ) 
+        
         # external inputs CA3        
-        self.Adend3AMPA_ec2180  = Synapse(sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3,  e=0) 
-        self.Adend3NMDA_ec2180  = SynapseNMDA(sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0)
-        self.Adend3AMPA_ec2360  = Synapse(sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3,  e=0)                                         # not initially used
-        self.Adend3NMDA_ec2360  = SynapseNMDA(sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0)  # not initially used
-        self.Adend1AMPA_dgreg   = Synapse(sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3,  e=0)
-        self.Adend1NMDA_dgreg   = SynapseNMDA(sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0)
-        self.Adend1AMPA_dgburst = Synapse(sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3,  e=0) 
-        self.Adend1NMDA_dgburst = SynapseNMDA(sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0)
+        self.Adend3AMPA_ec2180  = Synapse(     sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3,  e=0 ) 
+        self.Adend3NMDA_ec2180  = SynapseNMDA( sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0 )
+        self.Adend3AMPA_ec2360  = Synapse(     sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3,  e=0 )                                         # not initially used
+        self.Adend3NMDA_ec2360  = SynapseNMDA( sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0 )  # not initially used
+        self.Adend1AMPA_dgreg   = Synapse(     sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3,  e=0 )
+        self.Adend1NMDA_dgreg   = SynapseNMDA( sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0 )
+        self.Adend1AMPA_dgburst = Synapse(     sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3,  e=0 ) 
+        self.Adend1NMDA_dgburst = SynapseNMDA( sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0 )
+        
         # external inputs in CA1 (assiming this as the pyr CA1) s
-        self.Adend3AMPA_ec3180  = Synapse(sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3,  e=0)                                         # not initially used
-        self.Adend3NMDA_ec3180  = SynapseNMDA(sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0)  # not initially used
-        self.Adend3AMPA_ec3360  = Synapse(sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3,  e=0)
-        self.Adend3NMDA_ec3360  = SynapseNMDA(sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0)
-        self.Adend1AMPA_pyrCA3  = Synapse(sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3,  e=0)
-        self.Adend1NMDA_pyrCA3  = SynapseNMDA(sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0)
+        self.Adend3AMPA_ec3180  = Synapse(     sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3,  e=0 )                                         # not initially used
+        self.Adend3NMDA_ec3180  = SynapseNMDA( sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0 )  # not initially used
+        self.Adend3AMPA_ec3360  = Synapse(     sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3,  e=0 )
+        self.Adend3NMDA_ec3360  = SynapseNMDA( sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0 )
+        self.Adend1AMPA_pyrCA3  = Synapse(     sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3,  e=0 )
+        self.Adend1NMDA_pyrCA3  = SynapseNMDA( sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0 )
+        
         # connections in CA3
-        self.somaGABA_bas      = Synapse(sect=self.soma, loc=0.5, tau1=0.07, tau2=9.1, e=-80)
-        self.Adend3GABA_olm    = Synapse(sect=self.Adend3, loc=0.5, tau1=0.07, tau2=9.1, e=-80)
-        self.BdendAMPA_pyr     = Synapse(sect=self.Bdend, loc=0.5, tau1=0.05, tau2=5.3, e=0)
-        self.BdendNMDA_pyr     = SynapseNMDA(sect=self.Bdend, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0)
-        # connections in CA1 (same as previous) +
-        self.somaGABA_cck      = Synapse(sect=self.soma, loc=0.5, tau1=0.07, tau2=9.1, e=-80)
-        self.Adend2GABA_cck    = Synapse(sect=self.Adend2, loc=0.5, tau1=0.07, tau2=9.1, e=-80)
+        self.somaGABA_bas      = Synapse(      sect=self.soma,   loc=0.7, tau1=0.07, tau2=9.1, e=-80 )
+        self.Adend3GABA_olm    = Synapse(      sect=self.Adend3, loc=0.7, tau1=0.07, tau2=9.1, e=-80 )
+        self.BdendAMPA_pyr     = Synapse(      sect=self.Bdend,  loc=0.5, tau1=0.05, tau2=5.3, e=0   )
+        self.BdendNMDA_pyr     = SynapseNMDA(  sect=self.Bdend,  loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0 )
+        
+        # connections in CA1 (same as previous)
+        self.somaGABA_cck      = Synapse(      sect=self.soma,   loc=0.7, tau1=0.07, tau2=9.1, e=-80 )
+        self.Adend2GABA_cck    = Synapse(      sect=self.Adend2, loc=0.5, tau1=0.07, tau2=9.1, e=-80 )
       
         # self.somaGABAf   = Synapse(    sect=self.soma,   loc=0.5, tau1=0.07, tau2=9.1, e=-80.0) 
         # self.somaGABAfb  = Synapse(    sect=self.soma,   loc=0.3, tau1=0.07, tau2=9.1, e=-80.0) 
         # self.somaAMPAf   = Synapse(    sect=self.soma,   loc=0.7, tau1=0.05, tau2=5.3, e=0.0)
-        # self.BdendAMPAf  = Synapse(    sect=self.Bdend,  loc=0.5, tau1=0.05, tau2=5.3, e=0.0)
-        # self.BdendNMDA   = SynapseNMDA(sect=self.Bdend,  loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0.0)
-        # self.Adend1AMPAf = Synapse(    sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3, e=0.0)
-        # self.Adend1NMDA  = SynapseNMDA(sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0.0)
-        # self.Adend2GABAf = Synapse(    sect=self.Adend2, loc=0.5, tau1=0.07, tau2=9.1,  e=-80.0)
-        # self.Adend3GABAf = Synapse(    sect=self.Adend3, loc=0.7, tau1=0.07, tau2=9.1,  e=-80.0)
+        
+        # self.BdendAMPAf  = Synapse(     sect=self.Bdend,  loc=0.5, tau1=0.05, tau2=5.3, e=0.0)
+        # self.BdendNMDA   = SynapseNMDA( sect=self.Bdend,  loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0.0)
+        # self.Adend1AMPAf = Synapse(     sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3, e=0.0)
+        # self.Adend1NMDA  = SynapseNMDA( sect=self.Adend1, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0.0)
+        # self.Adend2GABAf = Synapse(     sect=self.Adend2, loc=0.5, tau1=0.07, tau2=9.1,  e=-80.0)
+        # self.Adend3GABAf = Synapse(     sect=self.Adend3, loc=0.7, tau1=0.07, tau2=9.1,  e=-80.0)
         # self.Adend3GABAfb = Synapse(    sect=self.Adend3, loc=0.7, tau1=0.07, tau2=9.1,  e=-80.0)
-        # self.Adend3AMPAf = Synapse(    sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3,  e=0.0)
-        # self.Adend3NMDA  = SynapseNMDA(sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0.0)
+        # self.Adend3AMPAf = Synapse(     sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3,  e=0.0)
+        # self.Adend3NMDA  = SynapseNMDA( sect=self.Adend3, loc=0.5, tau1=0.05, tau2=5.3, tau1NMDA=15.0, tau2NMDA=150.0, r=1, e=0.0)
       
         ### Synapses onto Adend1
         # self.syn_list = ['Adend3AMPAf','Adend3NMDA','Adend3GABAf', 'Adend2GABAf','Adend1AMPAf','Adend1NMDA',

--- a/files/files_final_version/parameters.py
+++ b/files/files_final_version/parameters.py
@@ -158,26 +158,27 @@ syn_inputs_neurons["ec3_360_to_bas_ca1"] = [["somaAMPA_ec3360","somaNMDA_ec3360"
 syn_inputs_neurons["ec3_360_to_cck_ca1"] = [["somaAMPA_ec3360","somaNMDA_ec3360"]]           # [["somaAMPAf", "somaNMDA"]]
 
 # to CA3 # added in 15/11
-delay_inputs_neurons["sep_180_to_bas_ca3"] = [2.0,1.0]
-delay_inputs_neurons["sep_360_to_olm_ca3"] = [2.0,1.0]
-delay_inputs_neurons["ec2_180_to_pyr_ca3"] = [2.0,1.0] # AMPA/ NMDA
-delay_inputs_neurons["ec2_180_to_bas_ca3"] = [2.0,1.0]
-delay_inputs_neurons["ec2_360_to_pyr_ca3"] = [2.0,1.0]
-delay_inputs_neurons["ec2_360_to_bas_ca3"] = [2.0,1.0]
-delay_inputs_neurons["dg_regular_to_pyr_ca3"] = [2.0,1.0]
-delay_inputs_neurons["dg_regular_to_bas_ca3"] = [2.0,1.0]
-delay_inputs_neurons["dg_burst_to_pyr_ca3"] = [2.0,1.0]
-delay_inputs_neurons["dg_burst_to_bas_ca3"] = [2.0,1.0]
+delay_external = 10.0
+delay_inputs_neurons["sep_180_to_bas_ca3"] = [delay_external,1.0]
+delay_inputs_neurons["sep_360_to_olm_ca3"] = [delay_external,1.0]
+delay_inputs_neurons["ec2_180_to_pyr_ca3"] = [delay_external,1.0] # AMPA/ NMDA
+delay_inputs_neurons["ec2_180_to_bas_ca3"] = [delay_external,1.0]
+delay_inputs_neurons["ec2_360_to_pyr_ca3"] = [delay_external,1.0]
+delay_inputs_neurons["ec2_360_to_bas_ca3"] = [delay_external,1.0]
+delay_inputs_neurons["dg_regular_to_pyr_ca3"] = [delay_external,1.0]
+delay_inputs_neurons["dg_regular_to_bas_ca3"] = [delay_external,1.0]
+delay_inputs_neurons["dg_burst_to_pyr_ca3"] = [delay_external,1.0]
+delay_inputs_neurons["dg_burst_to_bas_ca3"] = [delay_external,1.0]
 # to CA1
-delay_inputs_neurons["sep_180_to_bas_ca1"] = [2.0,1.0]
-delay_inputs_neurons["sep_360_to_olm_ca1"] = [2.0,1.0]
-delay_inputs_neurons["sep_180_to_cck_ca1"] = [2.0,1.0]
-delay_inputs_neurons["ec3_180_to_pyr_ca1"] = [2.0,1.0]
-delay_inputs_neurons["ec3_180_to_bas_ca1"] = [2.0,1.0]
-delay_inputs_neurons["ec3_180_to_cck_ca1"] = [2.0,1.0]
-delay_inputs_neurons["ec3_360_to_pyr_ca1"] = [2.0,1.0]
-delay_inputs_neurons["ec3_360_to_bas_ca1"] = [2.0,1.0]
-delay_inputs_neurons["ec3_360_to_cck_ca1"] = [2.0,1.0]
+delay_inputs_neurons["sep_180_to_bas_ca1"] = [delay_external,1.0]
+delay_inputs_neurons["sep_360_to_olm_ca1"] = [delay_external,1.0]
+delay_inputs_neurons["sep_180_to_cck_ca1"] = [delay_external,1.0]
+delay_inputs_neurons["ec3_180_to_pyr_ca1"] = [delay_external,1.0]
+delay_inputs_neurons["ec3_180_to_bas_ca1"] = [delay_external,1.0]
+delay_inputs_neurons["ec3_180_to_cck_ca1"] = [delay_external,1.0]
+delay_inputs_neurons["ec3_360_to_pyr_ca1"] = [delay_external,1.0]
+delay_inputs_neurons["ec3_360_to_bas_ca1"] = [delay_external,1.0]
+delay_inputs_neurons["ec3_360_to_cck_ca1"] = [delay_external,1.0]
 
 '''#############################################################################
                     Parameters: Background

--- a/files/files_final_version/parameters_alt.py
+++ b/files/files_final_version/parameters_alt.py
@@ -1,0 +1,244 @@
+'''#############################################################################
+Date: 24/11/2022
+
+version where I start removing everything related with basket and olm cells (by now)
+in ca1. The rest is ok to keep
+#############################################################################'''
+
+
+''' ############################################################################
+            Parameters: neurons -> neurons
+#############################################################################'''
+weights_neurons_neurons = {}
+nsyns_neurons_neurons = {}
+syn_neurons_neurons  = {}
+delay_neurons_neurons = {}
+
+scale = 0.87 # to compensate the fast part of NMDA that I do not understand
+# Internal CA3
+#weights_neurons_neurons["pyr_ca3_to_pyr_ca3"] = [[0.02348e-3, 0.004e-3]] # [0.02e-3+scale*0.004e-3, 0.004e-3]
+#weights_neurons_neurons["bas_ca3_to_pyr_ca3"] = [[0.576e-3]] # [0.8*0.72e-3]
+#weights_neurons_neurons["olm_ca3_to_pyr_ca3"] = [[57.6e-3]]  # [0.8*72.0e-3] #*0.9
+#weights_neurons_neurons["pyr_ca3_to_bas_ca3"] = [[1.5606e-3, 1.38e-3]] #[0.36e-3+scale*1.38e-3, 1.38e-3]
+#weights_neurons_neurons["bas_ca3_to_bas_ca3"] = [[4.5e-3]]
+#eights_neurons_neurons["pyr_ca3_to_olm_ca3"] = [[0.969e-3, 0.7e-3]] #[0.36e-3+scale*0.7e-3, 0.7e-3]
+# Internal CA1
+#weights_neurons_neurons["bas_ca1_to_pyr_ca1"] = [[0.576e-3]] # [0.8*0.72e-3]
+#weights_neurons_neurons["olm_ca1_to_pyr_ca1"] = [[57.6e-3]]  # [0.8*72.0e-3] #*0.9
+#weights_neurons_neurons["pyr_ca1_to_bas_ca1"] = [[1.5606e-3, 1.38e-3]] # [0.36e-3+scale*1.38e-3, 1.38e-3]
+#weights_neurons_neurons["bas_ca1_to_bas_ca1"] = [[4.5e-3]]
+#weights_neurons_neurons["pyr_ca1_to_olm_ca1"] = [[0.969e-3, 0.7e-3]] # [0.36e-3+scale*0.7e-3, 0.7e-3]
+#weights_neurons_neurons["cck_ca1_to_pyr_ca1"] = [[0e-3, 0e-3]] # to be optimize # updated to
+
+# Schaffer colateral
+# weights_neurons_neurons["pyr_ca3_to_pyr_ca1"] = [[0e-3, 0e-3]] # to be optimize
+# weights_neurons_neurons["pyr_ca3_to_bas_ca1"] = [[0e-3, 0e-3]]# to be optimize
+# weights_neurons_neurons["pyr_ca3_to_cck_ca1"] = [[0e-3, 0e-3]] # to be optimize
+
+# Internal CA3
+nsyns_neurons_neurons["pyr_ca3_to_pyr_ca3"] = [25]
+nsyns_neurons_neurons["bas_ca3_to_pyr_ca3"] = [42]
+nsyns_neurons_neurons["olm_ca3_to_pyr_ca3"] = [10]
+nsyns_neurons_neurons["pyr_ca3_to_bas_ca3"] = [100]
+nsyns_neurons_neurons["bas_ca3_to_bas_ca3"] = [60]
+nsyns_neurons_neurons["pyr_ca3_to_olm_ca3"] = [10]
+# Internal CA1
+#nsyns_neurons_neurons["bas_ca1_to_pyr_ca1"] = [42]
+#nsyns_neurons_neurons["olm_ca1_to_pyr_ca1"] = [10]
+#nsyns_neurons_neurons["pyr_ca1_to_bas_ca1"] = [100]
+#nsyns_neurons_neurons["bas_ca1_to_bas_ca1"] = [60]
+#nsyns_neurons_neurons["pyr_ca1_to_olm_ca1"] = [10]
+#nsyns_neurons_neurons["cck_ca1_to_pyr_ca1"] = [25,25] # to optimized # esto hay que tocarlo, habria que poner [ int(0.7*n), int(0.3*n)]
+
+# Internal CA3
+syn_neurons_neurons["pyr_ca3_to_pyr_ca3"] = [["BdendAMPA_pyr","BdendNMDA_pyr"]]  # [["BdendAMPAf","BdendNMDA"]]
+syn_neurons_neurons["bas_ca3_to_pyr_ca3"] = [["somaGABA_bas"]]                   # [["somaGABA"]]
+syn_neurons_neurons["olm_ca3_to_pyr_ca3"] = [["Adend3GABA_olm"]]                 # [["Adend3GABAfb"]]
+syn_neurons_neurons["pyr_ca3_to_bas_ca3"] = [["somaAMPA_pyr","somaNMDA_pyr"]]    # [["somaAMPAf", "somaNMDA"]]
+syn_neurons_neurons["bas_ca3_to_bas_ca3"] = [["somaGABA_bas"]]                   # [["somaGABAf"]]
+syn_neurons_neurons["pyr_ca3_to_olm_ca3"] = [["somaAMPA_pyr","somaNMDA_pyr"]]     # [["somaAMPAf","somaNMDA"]]
+# Internal CA1
+#syn_neurons_neurons["bas_ca1_to_pyr_ca1"] = [["somaGABA_pyr"]]                   # [["somaGABAf"]]
+#syn_neurons_neurons["olm_ca1_to_pyr_ca1"] = [["Adend3GABA_olm"]]                 # [["Adend3GABAfb"]]
+#syn_neurons_neurons["pyr_ca1_to_bas_ca1"] = [["somaAMPA_bas","somaNMDA_bas"]]    # [["somaAMPAf", "somaNMDA"]]
+#syn_neurons_neurons["bas_ca1_to_bas_ca1"] = [["somaGABA_bas"]]                   # [["somaGABAf"]]
+#syn_neurons_neurons["pyr_ca1_to_olm_ca1"] = [["somaAMPA_pyr","somaNMDA_pyr"]]    # [["somaAMPAf","somaNMDA"]]
+#syn_neurons_neurons["cck_ca1_to_pyr_ca1"] = [["Adend2GABA_cck", "somaGABA_cck"]] # [["Adend2GABAf", "somaGABAf"]] # updated on
+# Schaffer colaterals
+# syn_neurons_neurons["pyr_ca3_to_pyr_ca1"] = [["Adend1AMPAf","Adend1NMDA"]]
+# syn_neurons_neurons["pyr_ca3_to_bas_ca1"] = [["somaAMPAf","somaNMDA"]]
+# syn_neurons_neurons["pyr_ca3_to_cck_ca1"] = [["somaAMPAf","somaNMDA"]]
+
+# Internal CA3 # Added in 15/11
+delay_neurons_neurons["pyr_ca3_to_pyr_ca3"] = [2.0,1.0]
+delay_neurons_neurons["bas_ca3_to_pyr_ca3"] = [2.0,1.0]
+delay_neurons_neurons["olm_ca3_to_pyr_ca3"] = [2.0,1.0]
+delay_neurons_neurons["pyr_ca3_to_bas_ca3"] = [2.0,1.0]
+delay_neurons_neurons["bas_ca3_to_bas_ca3"] = [2.0,1.0]
+delay_neurons_neurons["pyr_ca3_to_olm_ca3"] = [2.0,1.0]
+
+# Internal CA1
+#delay_neurons_neurons["bas_ca1_to_pyr_ca1"] = [2.0,1.0]
+#delay_neurons_neurons["olm_ca1_to_pyr_ca1"] = [2.0,1.0]
+#delay_neurons_neurons["pyr_ca1_to_bas_ca1"] = [2.0,1.0]
+#delay_neurons_neurons["pyr_ca1_to_cck_ca1"] = [2.0,1.0]
+#delay_neurons_neurons["bas_ca1_to_bas_ca1"] = [2.0,1.0]
+#delay_neurons_neurons["pyr_ca1_to_olm_ca1"] = [2.0,1.0]
+#delay_neurons_neurons["cck_ca1_to_pyr_ca1"] = [2.0,1.0]
+# Schaffer colaterals
+# syn_neurons_neurons["pyr_ca3_to_pyr_ca1"] = [2.0]
+# syn_neurons_neurons["pyr_ca3_to_bas_ca1"] = [2.0]
+# syn_neurons_neurons["pyr_ca3_to_cck_ca1"] = [2.0]
+
+''' ############################################################################
+            Parameters: inputs -> neurons
+#############################################################################'''
+weights_inputs_neurons = {}
+nsyns_inputs_neurons   = {}
+syn_inputs_neurons     = {}
+delay_inputs_neurons   = {}
+
+# to CA3
+#weights_inputs_neurons["sep_180_to_bas_ca3"] = [[6.4e-4]]
+#weights_inputs_neurons["sep_360_to_olm_ca3"] = [[3.2e-4]]
+#weights_inputs_neurons["ec2_180_to_pyr_ca3"] = [[3.3e-4, 1.8e-4]] # AMPA/ NMDA
+#weights_inputs_neurons["ec2_180_to_bas_ca3"] = [[3.3e-4, 1.8e-4]]
+#weights_inputs_neurons["ec2_360_to_pyr_ca3"] = [[0.0,0.0]]
+#weights_inputs_neurons["ec2_360_to_bas_ca3"] = [[0.0,0.0]]
+#weights_inputs_neurons["dg_regular_to_pyr_ca3"] = [[0.9e-4,0.5e-4]]
+#weights_inputs_neurons["dg_regular_to_bas_ca3"] = [[0.9e-4,0.5e-4]]
+#weights_inputs_neurons["dg_burst_to_pyr_ca3"] = [[0.2*0.9e-4, 0.2*0.5e-4]]
+#weights_inputs_neurons["dg_burst_to_bas_ca3"] = [[0.2*0.9e-4, 0.2*0.5e-4]]
+# to CA1
+#weights_inputs_neurons["sep_180_to_bas_ca1"] = [[6.4e-4]]
+#weights_inputs_neurons["sep_360_to_olm_ca1"] = [[3.2e-4]]
+#weights_inputs_neurons["ec3_180_to_pyr_ca1"] = [[0.0,0.0]]
+#weights_inputs_neurons["ec3_180_to_bas_ca1"] = [[0.0,0.0]]
+#weights_inputs_neurons["ec3_180_to_cck_ca1"] = [[0.0,0.0]]
+#weights_inputs_neurons["ec3_360_to_pyr_ca1"] = [[3.3e-4, 1.8e-4]]
+#weights_inputs_neurons["ec3_360_to_bas_ca1"] = [[3.3e-4, 1.8e-4]]
+#weights_inputs_neurons["ec3_360_to_cck_ca1"] = [[3.3e-4, 1.8e-4]]
+
+# to CA3
+nsyns_inputs_neurons["sep_180_to_bas_ca3"] = [10]
+nsyns_inputs_neurons["sep_360_to_olm_ca3"] = [10]
+nsyns_inputs_neurons["ec2_180_to_pyr_ca3"] = [25]
+nsyns_inputs_neurons["ec2_180_to_bas_ca3"] = [25]
+nsyns_inputs_neurons["ec2_360_to_pyr_ca3"] = [25]
+nsyns_inputs_neurons["ec2_360_to_bas_ca3"] = [25]
+nsyns_inputs_neurons["dg_regular_to_pyr_ca3"] = [25]
+nsyns_inputs_neurons["dg_regular_to_bas_ca3"] = [25]
+nsyns_inputs_neurons["dg_burst_to_pyr_ca3"] = [10]
+nsyns_inputs_neurons["dg_burst_to_bas_ca3"] = [10]
+# to CA1
+#nsyns_inputs_neurons["sep_180_to_bas_ca1"] = [10]
+#nsyns_inputs_neurons["sep_360_to_olm_ca1"] = [10]
+#nsyns_inputs_neurons["ec3_180_to_pyr_ca1"] = [25]
+#nsyns_inputs_neurons["ec3_180_to_bas_ca1"] = [25]
+#nsyns_inputs_neurons["ec3_180_to_cck_ca1"] = [25]
+#nsyns_inputs_neurons["ec3_360_to_pyr_ca1"] = [25]
+#nsyns_inputs_neurons["ec3_360_to_bas_ca1"] = [25]
+#nsyns_inputs_neurons["ec3_360_to_cck_ca1"] = [25]
+
+# to CA3
+syn_inputs_neurons["sep_180_to_bas_ca3"]    = [["somaGABA_sep180"]]                          # [["somaGABAf"]]
+syn_inputs_neurons["sep_360_to_olm_ca3"]    = [["somaGABA_sep360"]]                          # [["somaGABAf"]]
+syn_inputs_neurons["ec2_180_to_pyr_ca3"]    = [["Adend3AMPA_ec2180", "Adend3NMDA_ec2180"]]   # [["Adend3AMPAf","Adend3NMDA"]]
+syn_inputs_neurons["ec2_180_to_bas_ca3"]    = [["somaAMPA_ec2180",   "somaNMDA_ec2180"]]     # [["somaAMPAf", "somaNMDA"]]
+syn_inputs_neurons["ec2_360_to_pyr_ca3"]    = [["Adend3AMPA_ec2360", "Adend3NMDA_ec2360"]]   # [["Adend3AMPAf","Adend3NMDA"]]
+syn_inputs_neurons["ec2_360_to_bas_ca3"]    = [["somaAMPA_ec2360",   "somaNMDA_ec2360"]]     # [["somaAMPAf", "somaNMDA"]]
+syn_inputs_neurons["dg_regular_to_pyr_ca3"] = [["Adend1AMPA_dgreg","Adend1NMDA_dgreg"]]      # [["Adend1AMPAf","Adend1NMDA"]]
+syn_inputs_neurons["dg_regular_to_bas_ca3"] = [["somaAMPA_dgreg","somaNMDA_dgreg"]]          # [["somaAMPAf", "somaNMDA"]]
+syn_inputs_neurons["dg_burst_to_pyr_ca3"]   = [["Adend1AMPA_dgburst","Adend1NMDA_dgburst"]]  # [["Adend1AMPAf","Adend1NMDA"]]
+syn_inputs_neurons["dg_burst_to_bas_ca3"]   = [["somaAMPA_dgburst", "somaNMDA_dgburst"]]     # [["somaAMPAf", "somaNMDA"]]
+# to CA1
+#syn_inputs_neurons["sep_180_to_bas_ca1"] = [["somaGABA_sep180"]]                             # [["somaGABAf"]]
+#syn_inputs_neurons["sep_360_to_olm_ca1"] = [["somaGABA_sep360"]]                             # [["somaGABAf"]]
+#syn_inputs_neurons["ec3_180_to_pyr_ca1"] = [["Adend3AMPA_ec3180","Adend3NMDA_ec3180"]]       # [["Adend3AMPAf", "Adend3NMDA"]]
+#syn_inputs_neurons["ec3_180_to_bas_ca1"] = [["somaAMPA_ec3180","somaNMDA_ec3180"]]           # [["somaAMPAf", "somaNMDA"]]
+#syn_inputs_neurons["ec3_180_to_cck_ca1"] = [["somaAMPA_ec3180","somaNMDA_ec3180"]]           # [["somaAMPAf", "somaNMDA"]]
+#syn_inputs_neurons["ec3_360_to_pyr_ca1"] = [["Adend3AMPA_ec3360","Adend3NMDA_ec3360"]]       # [["Adend3AMPAf", "Adend3NMDA"]]
+#syn_inputs_neurons["ec3_360_to_bas_ca1"] = [["somaAMPA_ec3360","somaNMDA_ec3360"]]           # [["somaAMPAf", "somaNMDA"]]
+#syn_inputs_neurons["ec3_360_to_cck_ca1"] = [["somaAMPA_ec3360","somaNMDA_ec3360"]]           # [["somaAMPAf", "somaNMDA"]]
+
+# to CA3 # added in 15/11
+delay_ext = 10.0
+delay_inputs_neurons["sep_180_to_bas_ca3"] = [delay_ext,1.0]
+delay_inputs_neurons["sep_360_to_olm_ca3"] = [delay_ext,1.0]
+delay_inputs_neurons["ec2_180_to_pyr_ca3"] = [delay_ext,1.0] # AMPA/ NMDA
+delay_inputs_neurons["ec2_180_to_bas_ca3"] = [delay_ext,1.0]
+delay_inputs_neurons["ec2_360_to_pyr_ca3"] = [delay_ext,1.0]
+delay_inputs_neurons["ec2_360_to_bas_ca3"] = [delay_ext,1.0]
+delay_inputs_neurons["dg_regular_to_pyr_ca3"] = [delay_ext,1.0]
+delay_inputs_neurons["dg_regular_to_bas_ca3"] = [delay_ext,1.0]
+delay_inputs_neurons["dg_burst_to_pyr_ca3"] = [delay_ext,1.0]
+delay_inputs_neurons["dg_burst_to_bas_ca3"] = [delay_ext,1.0]
+# to CA1
+#delay_inputs_neurons["sep_180_to_bas_ca1"] = [2.0,1.0]
+#delay_inputs_neurons["sep_360_to_olm_ca1"] = [2.0,1.0]
+#delay_inputs_neurons["sep_180_to_cck_ca1"] = [2.0,1.0]
+#delay_inputs_neurons["ec3_180_to_pyr_ca1"] = [2.0,1.0]
+#delay_inputs_neurons["ec3_180_to_bas_ca1"] = [2.0,1.0]
+#delay_inputs_neurons["ec3_180_to_cck_ca1"] = [2.0,1.0]
+#delay_inputs_neurons["ec3_360_to_pyr_ca1"] = [2.0,1.0]
+#delay_inputs_neurons["ec3_360_to_bas_ca1"] = [2.0,1.0]
+#delay_inputs_neurons["ec3_360_to_cck_ca1"] = [2.0,1.0]
+
+
+'''#############################################################################
+                    Parameters: Background
+#############################################################################'''
+
+keys = ["pyr_ca3","bas_ca3","olm_ca3","pyr_ca1", "bas_ca1","olm_ca1","cck_ca1"]
+weights_noise_neurons = dict.fromkeys(keys)
+for key in keys:
+    weights_noise_neurons[key] = {}
+
+# weights_noise_neurons["pyr_ca3"]["somaAMPAf"]   = 0.05e-3
+# weights_noise_neurons["pyr_ca3"]["somaGABAf"]   = 0.012e-3
+weights_noise_neurons["pyr_ca3"]["somaAMPA_noise"]   = 0.05e-3
+weights_noise_neurons["pyr_ca3"]["somaGABA_noise"]   = 0.012e-3
+                                             
+# weights_noise_neurons["pyr_ca3"]["Adend3AMPAf"] = 2*0.05e-3
+# weights_noise_neurons["pyr_ca3"]["Adend3GABAf"] = 0.012e-3
+# weights_noise_neurons["pyr_ca3"]["Adend3NMDA"]  = 0.0
+weights_noise_neurons["pyr_ca3"]["Adend3AMPA_noise"] = 2*0.05e-3
+weights_noise_neurons["pyr_ca3"]["Adend3GABA_noise"] = 0.012e-3
+# weights_noise_neurons["pyr_ca3"]["Adend3NMDA_noise"] = 0.0
+                                             
+# weights_noise_neurons["bas_ca3"]["somaAMPAf"]   = 0.02e-3
+# weights_noise_neurons["bas_ca3"]["somaGABAf"]   = 0.2e-3
+weights_noise_neurons["bas_ca3"]["somaAMPA_noise"]   = 0.02e-3
+weights_noise_neurons["bas_ca3"]["somaGABA_noise"]   = 0.2e-3
+                                             
+# weights_noise_neurons["olm_ca3"]["somaAMPAf"]   = 0.0625e-3
+# weights_noise_neurons["olm_ca3"]["somaGABAf"]   = 0.2e-3
+weights_noise_neurons["olm_ca3"]["somaAMPA_noise"]   = 0.0625e-3
+weights_noise_neurons["olm_ca3"]["somaGABA_noise"]   = 0.2e-3
+                                             
+# weights_noise_neurons["pyr_ca1"]["somaAMPAf"]   = 0.05e-3
+# weights_noise_neurons["pyr_ca1"]["somaGABAf"]   = 0.012e-3
+weights_noise_neurons["pyr_ca1"]["somaAMPA_noise"]   = 0.05e-3
+weights_noise_neurons["pyr_ca1"]["somaGABA_noise"]   = 0.012e-3
+
+# weights_noise_neurons["pyr_ca1"]["Adend3AMPAf"] = 2*0.05e-3
+# weights_noise_neurons["pyr_ca1"]["Adend3GABAf"] = 0.012e-3
+# weights_noise_neurons["pyr_ca1"]["Adend3NMDA"]  = 0.0
+weights_noise_neurons["pyr_ca1"]["Adend3AMPA_noise"] = 2*0.05e-3
+weights_noise_neurons["pyr_ca1"]["Adend3GABA_noise"] = 0.012e-3
+# weights_noise_neurons["pyr_ca1"]["Adend3NMDA_noise"]  = 0.0
+
+# weights_noise_neurons["bas_ca1"]["somaAMPAf"]   = 0.02e-3
+# weights_noise_neurons["bas_ca1"]["somaGABAf"]   = 0.2e-3
+weights_noise_neurons["bas_ca1"]["somaAMPA_noise"]   = 0.02e-3
+weights_noise_neurons["bas_ca1"]["somaGABA_noise"]   = 0.2e-3
+                                             
+# weights_noise_neurons["olm_ca1"]["somaAMPAf"]   = 0.0625e-3
+# weights_noise_neurons["olm_ca1"]["somaGABAf"]   = 0.2e-3
+weights_noise_neurons["olm_ca1"]["somaAMPA_noise"]   = 0.0625e-3
+weights_noise_neurons["olm_ca1"]["somaGABA_noise"]   = 0.2e-3
+                                             
+# weights_noise_neurons["cck_ca1"]["somaAMPAf"]   = 0.045e-3 # updated on 15/11/2022
+# weights_noise_neurons["cck_ca1"]["somaGABAf"]   = 0.012e-3
+weights_noise_neurons["cck_ca1"]["somaAMPA_noise"]   = 0.045e-3 # updated on 15/11/2022
+weights_noise_neurons["cck_ca1"]["somaGABA_noise"]   = 0.012e-3

--- a/files/files_final_version/run_baselineCA3.py
+++ b/files/files_final_version/run_baselineCA3.py
@@ -102,7 +102,11 @@ save_data_ica    = True
 # output of ca3 will be stored in the same folder as the external inputs
 current_folder = os.getcwd()
 inputs_folder = '/home/dimitrios/Neurons/CA1model/baselineCA3/external_inputs'
-save_folder   = '/home/dimitrios/Neurons/CA1model/baselineCA3/'
+
+file_name = __file__
+file_name = file_name.replace(current_folder,"") 
+file_name = file_name.split('_')[-1][:-3] 
+save_folder = os.path.join(current_folder, file_name)
 #save_folder = os.path.join(current_folder,"test_data")
 
 # file_name = __file__
@@ -544,7 +548,7 @@ if pc.id() == 0:
                 for j,sublfp_ in enumerate(np.array(lfp_.values_per_section).T):
                     data_ica["ca3"]["ica"].extend( np.array(sublfp_) )
                     data_ica["ca3"]["electrode"].extend( [zcoords[i]]*len(sublfp_) )
-                    data_ica["ca3"]["component"].extend( [zcoords[j]]*len(sublfp_) )
+                    data_ica["ca3"]["component"].extend( [["Bdend","soma","Adend1","Adend2","Adend3"][j]]*len(sublfp_) )
 
             data_ica["ca3"] = pd.DataFrame(data_ica["ca3"])
             for i in range(number_of_argvs):

--- a/files/files_final_version/store_CFC_final.py
+++ b/files/files_final_version/store_CFC_final.py
@@ -11,26 +11,44 @@ from signal_analysis import compute_coherence_measurements
 tick = tm.time()
 #Calculate the avg modulation inxed over iseed and bseed
 def get_avg_mi(fgamma,ftheta,fs,df,label,surrogate_test=False): 
-    mi = np.zeros((len(fgamma),len(ftheta)))
-    for input1 in np.unique(df["iseed"].values):
-        for input2 in np.unique(df["ibseed"].values):
+    all_mi = []
+    all_inputs2={}
+    if(not surrogate_test):
+        all_inputs1=np.unique(df["iseed"].values)
+        for inp in all_inputs1:
+            all_inputs2[inp]=np.unique(df[df["iseed"]==inp]["ibseed"].values)
+    else:
+        all_inputs1=np.unique(df["iseed"].values)[-6:]
+        for inp in all_inputs1:
+            all_inputs2[inp]=np.unique(df[df["iseed"]==inp]["ibseed"].values)[-6:]
+    n_temps=0
+    for input1 in all_inputs1:
+        print(input1,all_inputs2[input1])
+        for input2 in all_inputs2[input1]:
+            n_temps+=1
             print(input1,input2,len(df))
             ts = df[label][(df['iseed'] == input1) & (df['ibseed'] == input2)].values
             ts=ts[len(ts)//15:]
             ftheta, fgamma, mi_temp, mi_sur_temp = compute_mi(ts, ftheta, fgamma, fs=fs, 
-                                          nbins=50, surrogate_test=surrogate_test, nsurrogates=10,choiseSurr = 2) 
+                                          nbins=20, surrogate_test=surrogate_test, nsurrogates=100,choiseSurr = 2) 
             mi_temp = np.swapaxes(mi_temp,0,1)
             mi_sur_temp= np.swapaxes(mi_sur_temp,1,2)
             if(surrogate_test):
                 inds_insig = mi_temp<=np.quantile(np.array(mi_sur_temp),0.995,axis=0)
                 mi_temp[inds_insig] = 0
-            mi=mi+mi_temp
-    return mi/len(np.unique(df["iseed"].values))/len(np.unique(df["ibseed"].values))
+            
+            all_mi.append(mi_temp)
+    print(n_temps)
+    return all_mi
 
 current_folder = os.getcwd()
-folder = os.path.join(current_folder, "baselineCA3")
-ts_choise = ["lfp","ica","synapses_pyr"][1]
-area="ca3"
+folder = os.path.join(current_folder, "lessDGburstCA1-12")
+input1 = int(sys.argv[1])
+ts_choise = ["lfp","ica","synapses_pyr"][input1]
+if "CA1" in folder.split('/')[-1]:
+    area="ca1"
+else:
+    area="ca3"
 surrogate_test=False
 
 df= file_management.load_lzma(os.path.join(folder,ts_choise+"_"+area+".lzma"))
@@ -41,40 +59,47 @@ if(ts_choise=="lfp"):
     ts_ = df[ts_choise][(df["electrode"]==elec_pos)&(df["iseed"]==ised)&(df["ibseed"]==bsed)].values
     pos_vals = np.unique(df["electrode"].values)
 elif(ts_choise=="ica"):
+    elec_comp=np.unique(df["component"].values)[0]
     elec_pos = np.unique(df["electrode"].values)[0]
-    ts_ = df[ts_choise][(df["electrode"]==elec_pos)&(df["component"]==elec_pos)&(df["iseed"]==ised)&(df["ibseed"]==bsed)].values
-    pos_vals = np.unique(df["electrode"].values)
+    ts_ = df[ts_choise][(df["electrode"]==elec_pos)&(df["component"]==elec_comp)&(df["iseed"]==ised)&(df["ibseed"]==bsed)].values
+    pos_vals = ["Bdend","soma","Adend1","Adend2","Adend3"]
 elif(ts_choise=="synapses_pyr"):
     all_comp=["Bdend","soma","Adend1","Adend2","Adend3"]
     df= file_management.load_lzma(os.path.join(folder,ts_choise+"_"+area+".lzma"))
-    df = pd.concat([*[df.filter(like=comp).mean(axis=1) for comp in all_comp],*[df["iseed"],df["ibseed"]]],axis=1,keys=[*all_comp,"iseed","ibseed"])
+    df = pd.concat([*[df.filter(like=comp).filter(like="mean").sum(axis=1) for comp in all_comp],*[df["iseed"],df["ibseed"]]],axis=1,keys=[*all_comp,"iseed","ibseed"])
     ts_ = df[all_comp[0]].values
     df.fillna(0,inplace=True)
     pos_vals = all_comp
 
 fs = 500
-ftheta_min,ftheta_max = 4,20
+ftheta_min,ftheta_max = 2,15
 fgamma_min,fgamma_max,dfgamma = 20,90,1
 nperseg = 500
 all_mi = {}
+all_mi_std = {}
 
 ftheta, fgamma, _, _, _, _ = compute_coherence_measurements(ts_, fs, nperseg, 0.75*nperseg, ftheta_min=ftheta_min, ftheta_max=ftheta_max, fgamma_min=fgamma_min, fgamma_max=fgamma_max, dfgamma=dfgamma,norder=4, nfft=2048,surrogate_test=False, nsurrogates=1,choiseSurr = None)
 for ind,pos in enumerate(pos_vals):
     if(ts_choise=="lfp"):
         df_pos = df[df["electrode"]==pos]
     elif(ts_choise=="ica"):
-        df_pos = df[(df["electrode"]==pos)&(df["component"]==pos)]
+        df_pos = df[(df["electrode"]==elec_pos)&(df["component"]==pos)]
     elif(ts_choise=="synapses_pyr"):
         df_pos = df[[pos,"iseed","ibseed"]]
         df_pos.rename(columns={pos:ts_choise},inplace=True)
-    all_mi[pos]= get_avg_mi(fgamma,ftheta,fs,df_pos,ts_choise,surrogate_test=False)
+    all_mi_temp =get_avg_mi(fgamma,ftheta,fs,df_pos,ts_choise,surrogate_test=surrogate_test) 
+    all_mi[pos]= np.mean(all_mi_temp,axis=0)
+    all_mi_std[pos]= np.std(all_mi_temp,axis=0)
 
-title = "CFC_"+ts_choise+"_"+area
+if(surrogate_test):
+    title = "CFC_sign_test"+ts_choise+"_"+area
+else:
+    title = "CFC_"+ts_choise+"_"+area
 
-file_management.save_lzma([all_mi,fgamma,ftheta],title,parent_dir=folder)
+file_management.save_lzma([all_mi,all_mi_std,fgamma,ftheta],title,parent_dir=folder)
 
-#file_name = __file__
-#store = 'cp '+__file__.replace(current_folder+"/","") +" "+ folder.replace(current_folder+"/","") +__file__.replace(current_folder,"")
+file_name = __file__
+store = 'cp '+__file__.replace(current_folder+"/","") +" "+ folder.replace(current_folder+"/","") +__file__.replace(current_folder,"")
 
 tock = tm.time()
 diff = tock-tick

--- a/files/files_final_version/store_CFD_final.py
+++ b/files/files_final_version/store_CFD_final.py
@@ -5,38 +5,58 @@ sys.path.append('/home/dimitrios/Neurons/CA1model/final_files')
 import file_management
 import time as tm
 from signal_analysis import compute_coherence_measurements
-
+import pandas as pd
 tick = tm.time()
 #Calculate the avg modulation inxed over all_input2. Input3 and 4 are used in order to load the file.
 def get_avg_cfd(fgamma,ftheta,fs,df,label,surrogate_test=False): 
-    all_psi = np.zeros((len(fgamma),len(ftheta)))
-    all_nu = np.zeros((len(fgamma),len(ftheta)))
-    for input1 in np.unique(df["iseed"].values):
-        for input2 in np.unique(df["ibseed"].values):
+    all_psi = []
+    all_nu = []
+    
+    #for input1 in np.unique(df["iseed"].values):
+    #    for input2 in np.unique(df["ibseed"].values):
+    all_inputs2={}
+    if(not surrogate_test):
+        all_inputs1=np.unique(df["iseed"].values)
+        for inp in all_inputs1:
+            all_inputs2[inp]=np.unique(df[df["iseed"]==inp]["ibseed"].values)
+    else:
+        all_inputs1=np.unique(df["iseed"].values)[-6:]
+        for inp in all_inputs1:
+            all_inputs2[inp]=np.unique(df[df["iseed"]==inp]["ibseed"].values)[-6:]
+    n_temps=0
+    for input1 in all_inputs1:
+        print(input1,all_inputs2[input1])
+        for input2 in all_inputs2[input1]:
             print(input1,input2,len(df))
+            n_temps+=1
             ts = df[label][(df['iseed'] == input1) & (df['ibseed'] == input2)].values
             ts=ts[len(ts)//15:]
             
             ftheta, fgamma, psi_temp, nu_temp, psi_sur_temp,nu_sur_temp = compute_coherence_measurements(ts, fs, nperseg, 0.75*nperseg, ftheta_min=ftheta_min, 
                                    ftheta_max=ftheta_max, fgamma_min=fgamma_min, fgamma_max=fgamma_max, dfgamma=dfgamma,
-                                   norder=4, nfft=2048,surrogate_test=surrogate_test, nsurrogates=100,choiseSurr = 2)
+                                   norder=4, nfft=2048, surrogate_test=surrogate_test, nsurrogates=100,choiseSurr = 2)
             psi_temp= np.array(psi_temp)
             nu_temp=np.array(nu_temp)
 
             if(surrogate_test):
                 inds_insig = np.logical_and(psi_temp>=np.quantile(np.array(psi_sur_temp),0.005,axis=0),psi_temp<=np.quantile(np.array(psi_sur_temp),0.995,axis=0))
                 psi_temp[inds_insig]=0
-                inds_insig = nu_temp<=np.quantile(np.array(nu_sur_temp),0.995,axis=0)
+                inds_insig = nu_temp<=np.quantile(np.array(nu_sur_temp),0.99,axis=0)
                 nu_temp[inds_insig]=0
         
-            all_psi+=psi_temp
-            all_nu+=nu_temp
-    return all_psi/len(np.unique(df["iseed"].values))/len(np.unique(df["ibseed"].values)),all_nu/len(np.unique(df["iseed"].values))/len(np.unique(df["ibseed"].values))
+            all_psi.append(psi_temp)
+            all_nu.append(nu_temp)
+    print(n_temps)
+    return all_psi,all_nu
 
 current_folder = os.getcwd()
-folder = os.path.join(current_folder, "baselineCA1")
-ts_choise = ["lfp","ica","synapses_pyr"][1]
-area="ca1"
+folder = os.path.join(current_folder, "lessDGburstCA1-12")
+input1 = int(sys.argv[1])
+ts_choise = ["lfp","ica","synapses_pyr"][input1]
+if "CA1" in folder.split('/')[-1]:
+    area="ca1"
+else:
+    area="ca3"
 surrogate_test=False
 
 
@@ -48,42 +68,50 @@ if(ts_choise=="lfp"):
     ts_ = df[ts_choise][(df["electrode"]==elec_pos)&(df["iseed"]==ised)&(df["ibseed"]==bsed)].values
     pos_vals = np.unique(df["electrode"].values)
 elif(ts_choise=="ica"):
+    elec_comp=np.unique(df["component"].values)[0]
     elec_pos = np.unique(df["electrode"].values)[0]
-    ts_ = df[ts_choise][(df["electrode"]==elec_pos)&(df["component"]==elec_pos)&(df["iseed"]==ised)&(df["ibseed"]==bsed)].values
-    pos_vals = np.unique(df["electrode"].values)
+    ts_ = df[ts_choise][(df["electrode"]==elec_pos)&(df["component"]==elec_comp)&(df["iseed"]==ised)&(df["ibseed"]==bsed)].values
+    pos_vals = ["Bdend","soma","Adend1","Adend2","Adend3"]
 elif(ts_choise=="synapses_pyr"):
     all_comp=["Bdend","soma","Adend1","Adend2","Adend3"]
     df= file_management.load_lzma(os.path.join(folder,ts_choise+"_"+area+".lzma"))
-    df = pd.concat([*[df.filter(like=comp).mean(axis=1) for comp in all_comp],*[df["iseed"],df["ibseed"]]],axis=1,keys=[*all_comp,"iseed","ibseed"])
+    df = pd.concat([*[df.filter(like=comp).filter(like="mean").sum(axis=1) for comp in all_comp],*[df["iseed"],df["ibseed"]]],axis=1,keys=[*all_comp,"iseed","ibseed"])
     ts_ = df[all_comp[0]].values
     df.fillna(0,inplace=True)
     pos_vals = all_comp
 
 fs = 500
-ftheta_min,ftheta_max = 4,20
+ftheta_min,ftheta_max = 2,15
 fgamma_min,fgamma_max,dfgamma = 20,90,1
 nperseg = 500
 
 all_psi= {}
+all_psi_std={}
 all_nu = {}
+all_nu_std={}
 
 ftheta, fgamma, _, _, _, _ = compute_coherence_measurements(ts_, fs, nperseg, 0.75*nperseg, ftheta_min=ftheta_min, ftheta_max=ftheta_max, fgamma_min=fgamma_min, fgamma_max=fgamma_max, dfgamma=dfgamma,norder=4, nfft=2048,surrogate_test=False, nsurrogates=1,choiseSurr = None)
 for ind,pos in enumerate(pos_vals):
     if(ts_choise=="lfp"):
         df_pos = df[df["electrode"]==pos]
     elif(ts_choise=="ica"):
-        df_pos = df[(df["electrode"]==pos)&(df["component"]==pos)]
+        df_pos = df[(df["electrode"]==elec_pos)&(df["component"]==pos)]
     elif(ts_choise=="synapses_pyr"):
         df_pos = df[[pos,"iseed","ibseed"]]
         df_pos.rename(columns={pos:ts_choise},inplace=True)
 
-    psi_tmp,nu_tmp= get_avg_cfd(fgamma,ftheta,fs,df_pos,ts_choise,surrogate_test=False)
-    all_psi[pos]=psi_tmp
-    all_nu[pos]=nu_tmp
+    psi_tmp,nu_tmp= get_avg_cfd(fgamma,ftheta,fs,df_pos,ts_choise,surrogate_test=surrogate_test)
+    all_psi[pos]=np.mean(psi_tmp,axis=0)
+    all_psi_std[pos]=np.std(psi_tmp,axis=0)
+    all_nu[pos]=np.mean(nu_tmp,axis=0)
+    all_nu_std[pos]=np.std(nu_tmp,axis=0)
 
-title = "CFD_"+ts_choise+"_"+area
+if(surrogate_test):
+    title = "CFD_sign_test"+ts_choise+"_"+area
+else:
+    title = "CFD_"+ts_choise+"_"+area
 
-file_management.save_lzma([all_psi,all_nu,fgamma,ftheta],title,parent_dir=folder)
+file_management.save_lzma([all_psi,all_psi_std,all_nu,all_nu_std,fgamma,ftheta],title,parent_dir=folder)
 
 file_name = __file__
 store = 'cp '+__file__.replace(current_folder+"/","") +" "+ folder.replace(current_folder+"/","") +__file__.replace(current_folder,"")


### PR DESCRIPTION
Many differences: 

- In terms of bugs:

1. Corrected a bug which made ec3 inputs arrive earlier by 10ms to each consecutive population: cck (10). bas (20), pyr (30). Now all ec spikes arrive 10ms earlier, as they should
2. In  process_syn_data( data_unified ) @ functions.py the previous function did not average the synaptic currents over all neurons.
3. In initialization in neurons.py all the threshold are by default 0.0. Without this, there were some weird inconsistencies between parallel and non-parallel runs. In more detail some neurons in parallel runs would have 0.0 and other neurons of the same population would have the NEURONS default. 
4. At PyrAdr_CA3 the location of the synaptic currents is variable so that no inhibition and excitation coexist in the same point.
5. Changed the external delay to CA3 from 2 -> 10,
6. Changed the external variability of the delay from CA3 from 10->1

- In terms of organization:

1. The run_example files where replaced by baselineCA3.py and baselineCA1.py.
7. baselineCA3.py uses parameters.py and baselineCA1.py uses parameters_alt.py

- In terms of functionality:

1. The inputs_parameters.py and external_inputs.py were modified in order to simulate a slower EC.