### PR TITLE
Changed filtering of signals.

### DIFF
--- a/files/signal_analysis.py
+++ b/files/signal_analysis.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import scipy 
-import copy 
+
 '''
 from neurodsp.filt import filter_signal
 from neurodsp.plts import plot_time_series
@@ -15,6 +15,7 @@ from bycycle.cyclepoints.zerox import find_flank_zerox
 from bycycle.plts import plot_burst_detect_summary, plot_cyclepoints_array
 from bycycle.utils.download import load_bycycle_data
 '''
+
 import os 
 import sys
 # import file_management
@@ -24,6 +25,7 @@ from scipy.signal import hilbert, chirp
 def hilbert_phase(x):
     sig=x-x.mean()
     std = sig.std()
+    #print("Len std: ",len(sig),std)
     sig/=std
     analytic_sig = hilbert(sig)
     instantaneous_phase = np.angle(analytic_sig)
@@ -157,8 +159,8 @@ def modulation_index_old(theta_phase, gamma_amplitude, fs=1e4, nbins=20, nsurrog
     else: 
         return modulation_index
 
-def compute_mi(timeseries, ftheta, fgamma, fs=1e3, nbins=20, surrogate_test=False, nsurrogates=100, surrogate_method = "block boostrapping", surrogate_nsplits=99): 
-    
+
+def compute_mi(timeseries, ftheta, fgamma, fs=1e3, nbins=20, surrogate_test=False, nsurrogates=100,choiseSurr=0,Filter_theta=1.0,Filter_gamma=10.0): 
     ntheta,  ngamma = len(ftheta), len(fgamma)
     
     mi = np.zeros((ntheta,ngamma))
@@ -171,9 +173,9 @@ def compute_mi(timeseries, ftheta, fgamma, fs=1e3, nbins=20, surrogate_test=Fals
     
     norder = 4
     for i,fth in enumerate(ftheta):
-        sig_band1[i], _, phase[i] = bandpass_filter_and_hilbert_transform(timeseries, fs=fs, f0=fth, df=1.0, norder=norder)
+        sig_band1[i], _, phase[i] = bandpass_filter_and_hilbert_transform3(timeseries, fs=fs, f0=fth, df=Filter_theta, norder=norder)
     for i,fg in enumerate(fgamma):
-        sig_band2[i], envelope[i], _ = bandpass_filter_and_hilbert_transform(timeseries, fs=fs, f0=fg, df=10.0, norder=norder)
+        sig_band2[i], envelope[i], _ = bandpass_filter_and_hilbert_transform3(timeseries, fs=fs, f0=fg, df=Filter_gamma, norder=norder)
 
     entropy_max = np.log(nbins)
     
@@ -196,15 +198,19 @@ def compute_mi(timeseries, ftheta, fgamma, fs=1e3, nbins=20, surrogate_test=Fals
             modulation_index = (entropy_max-entropy)/entropy_max
             mi[i,j] = modulation_index
             
-            if surrogate_test: 
-                surrogates = surrogate_generation( gamma_amplitude, nsurrogates=nsurrogates, method = surrogate_method, nsplits=surrogate_nsplits)
+            if surrogate_test:
+                if(choiseSurr==0):
+                    surrogates = surrogate_generation( gamma_amplitude, nsurrogates = nsurrogates)
+                elif(choiseSurr==1):
+                    surrogates = surrogate_generation( gamma_amplitude, nsurrogates = nsurrogates,nsplits=int(len(x)/nperseg))
+                elif(choiseSurr==2):
+                    surrogates = surrogate_generation( gamma_amplitude, nsurrogates = nsurrogates,method="2block boostrapping")
                 for l, surrogate in enumerate(surrogates): 
                     amplitude = np.zeros(len(pbins)-1)       
                     for k in range(len(pbins)-1):  
                         pl = pbins[k]
                         pr = pbins[k+1]                   
                         indices=(theta_phase>=pl) & (theta_phase<pr) 
-
                         amplitude[k] = np.mean(surrogate[indices]) 
                         
                     pi = amplitude/np.sum(amplitude)
@@ -214,190 +220,7 @@ def compute_mi(timeseries, ftheta, fgamma, fs=1e3, nbins=20, surrogate_test=Fals
                     
     return ftheta, fgamma, mi, mi_surrogates
 
-# new 15/01/2022
-def compute_mi_parallel(timeseries, ftheta, fgamma, fs=1e3, nbins=20, surrogate_test=False, nsurrogates=100, surrogate_method = "block boostrapping", surrogate_nsplits=99): 
-    
-    ngamma = len(fgamma)
-    mi = np.zeros(ngamma)
-    mi_surrogates = np.zeros((nsurrogates, ngamma))
 
-    sig_band2 = [ [] for i in range(ngamma)]
-    envelope  = [ [] for i in range(ngamma)]
-    
-    norder = 4
-    sig_band1, _, phase = bandpass_filter_and_hilbert_transform(timeseries, fs=fs, f0=ftheta, df=1.0, norder=norder)
-    for i,fg in enumerate(fgamma):
-        sig_band2[i], envelope[i], _ = bandpass_filter_and_hilbert_transform(timeseries, fs=fs, f0=fg, df=10.0, norder=norder)
-        
-    entropy_max = np.log(nbins)
-    np.random.seed(19)
-    theta_phase = phase
-    
-    for j in range(ngamma):
-        gamma_amplitude = envelope[j]
-        pbins = np.linspace(0,2*np.pi,nbins+1)
-        amplitude = np.zeros(len(pbins)-1)       
-        for k in range(len(pbins)-1):         
-            pl = pbins[k]
-            pr = pbins[k+1]                   
-            indices=(theta_phase>=pl) & (theta_phase<pr)  
-            amplitude[k] = np.mean(gamma_amplitude[indices]) 
-
-        pi = amplitude/np.sum(amplitude)
-        entropy = -np.sum(pi*np.log(pi))
-        modulation_index = (entropy_max-entropy)/entropy_max
-        mi[j] = modulation_index
-
-        if surrogate_test: 
-            surrogates = surrogate_generation( gamma_amplitude, nsurrogates=nsurrogates, method = surrogate_method, nsplits = surrogate_nsplits)
-            for l, surrogate in enumerate(surrogates): 
-                amplitude = np.zeros(len(pbins)-1)       
-                for k in range(len(pbins)-1):  
-                    pl = pbins[k]
-                    pr = pbins[k+1]                   
-                    indices=(theta_phase>=pl) & (theta_phase<pr) 
-
-                    amplitude[k] = np.mean(surrogate[indices]) 
-
-                pi = amplitude/np.sum(amplitude)
-                entropy = -np.sum(pi*np.log(pi))
-                modulation_index = (entropy_max-entropy)/entropy_max
-                mi_surrogates[l,j] = modulation_index
-                
-    return mi, mi_surrogates 
-
-def compute_mi_lists(timeseries, ftheta, fgamma, fs=1e3, nbins=20, surrogate_test=False, nsurrogates=100, surrogate_method = "block boostrapping", surrogate_nsplits=99): 
-    '''
-    timeseries is now a list
-    '''
-    ntrials = len(timeseries)
-    ntheta,  ngamma = len(ftheta), len(fgamma)
-    mi = np.zeros((ntheta,ngamma))
-    mi_surrogates = np.zeros((nsurrogates, ntheta, ngamma))
-
-    sig_band1 = [ [ [] for j in range(ntrials) ] for i in range(ntheta)]
-    sig_band2 = [ [ [] for j in range(ntrials) ] for i in range(ngamma)]
-    phase     = [ [ [] for j in range(ntrials) ] for i in range(ntheta)] 
-    envelope  = [ [ [] for j in range(ntrials) ] for i in range(ngamma)]
-    
-    norder = 4
-    for i,fth in enumerate(ftheta):
-        for j in range(ntrials):
-            sig_band1[i][j], _, phase[i][j] = bandpass_filter_and_hilbert_transform(timeseries[j], fs=fs, f0=fth, df=1.0, norder=norder)
-    for i,fg in enumerate(fgamma):
-        for j in range(ntrials):
-            sig_band2[i][j], envelope[i][j], _ = bandpass_filter_and_hilbert_transform(timeseries[j], fs=fs, f0=fg, df=10.0, norder=norder)
-
-    entropy_max = np.log(nbins)
-    
-    np.random.seed(19)
-    pbins = np.linspace(0,2*np.pi,nbins+1)
-    for i in range(ntheta):
-        #theta_phase = phase[i]
-        for j in range(ngamma):
-            #gamma_amplitude = envelope[j]
-            amplitude = np.zeros((ntrials,nbins))
-            for k in range(ntrials):
-                theta_phase = phase[i][k]
-                gamma_amplitude = envelope[j][k]
-                for l in range(len(pbins)-1):         
-                    pl = pbins[l]
-                    pr = pbins[l+1]                   
-                    indices=(theta_phase>=pl) & (theta_phase<pr)  
-                    amplitude[k,l] = np.mean(gamma_amplitude[indices]) 
-            amplitude = np.concatenate(amplitude, axis=0)
-            pi = amplitude/np.sum(amplitude)
-            entropy = -np.sum(pi*np.log(pi))
-            modulation_index = (entropy_max-entropy)/entropy_max
-            mi[i,j] = modulation_index
-            
-    if surrogate_test: 
-        for i in range(ntheta):
-            for j in range(ngamma):
-                surrogates = surrogate_generation_list( envelope[j], nsurrogates=nsurrogates, method = surrogate_method, nsplits=surrogate_nsplits)
-                for s, surrogate in enumerate(surrogates):
-                    amplitude = np.zeros((ntrials, nbins))
-                    for k in range(ntrials):
-                        theta_phase = phase[i][k]
-                        for l in range(len(pbins)-1):
-                            pl = pbins[l]
-                            pr = pbins[l+1]                   
-                            indices=(theta_phase>=pl) & (theta_phase<pr)  
-                            amplitude[k,l] = np.mean(surrogate[k][indices]) 
-
-                    amplitude = np.concatenate(amplitude, axis=0)
-                    pi = amplitude/np.sum(amplitude)
-                    entropy = -np.sum(pi*np.log(pi))
-                    modulation_index = (entropy_max-entropy)/entropy_max
-                    mi[s,i,j] = modulation_index
-
-    return ftheta, fgamma, mi, mi_surrogates
-
-def compute_mi_lists_parallel(timeseries, ftheta, fgamma, fs=1e3, nbins=20, surrogate_test=False, nsurrogates=100, surrogate_method = "block boostrapping", surrogate_nsplits=99): 
-    '''
-    timeseries is now a list
-    ftheta is scalar not a list/array
-    '''
-    ntrials = len(timeseries)
-    ntheta,  ngamma = len(ftheta), len(fgamma)
-    mi = np.zeros((ntheta,ngamma))
-    mi_surrogates = np.zeros((nsurrogates, ntheta, ngamma))
-
-    sig_band1 = [ [] for j in range(ntrials) ] 
-    sig_band2 = [ [ [] for j in range(ntrials) ] for i in range(ngamma)]
-    phase     = [ [] for j in range(ntrials) ] 
-    envelope  = [ [ [] for j in range(ntrials) ] for i in range(ngamma)]
-    
-    norder = 4
-    for j in range(ntrials):
-        sig_band1[j], _, phase[j] = bandpass_filter_and_hilbert_transform(timeseries[j], fs=fs, f0=ftheta, df=1.0, norder=norder)
-    for i,fg in enumerate(fgamma):
-        for j in range(ntrials):
-            sig_band2[i][j], envelope[i][j], _ = bandpass_filter_and_hilbert_transform(timeseries[j], fs=fs, f0=fg, df=10.0, norder=norder)
-
-    entropy_max = np.log(nbins)
-    np.random.seed(19)
-    pbins = np.linspace(0,2*np.pi,nbins+1)
-    # theta_phase = phase[i]
-    for j in range(ngamma):
-        # gamma_amplitude = envelope[j]
-        amplitude = np.zeros((ntrials,nbins))
-        for k in range(ntrials):
-            theta_phase = phase[k]
-            gamma_amplitude = envelope[j][k]
-            for l in range(len(pbins)-1):         
-                pl = pbins[l]
-                pr = pbins[l+1]                   
-                indices=(theta_phase>=pl) & (theta_phase<pr)  
-                amplitude[k,l] = np.mean(gamma_amplitude[indices]) 
-        amplitude = np.concatenate(amplitude, axis=0)
-        pi = amplitude/np.sum(amplitude)
-        entropy = -np.sum(pi*np.log(pi))
-        modulation_index = (entropy_max-entropy)/entropy_max
-        mi[j] = modulation_index
-        
-    if surrogate_test: 
-        for j in range(ngamma):
-            surrogates = surrogate_generation_list( envelope[j], nsurrogates=nsurrogates, method = surrogate_method, nsplits=surrogate_nsplits)
-            for s, surrogate in enumerate(surrogates):
-                amplitude = np.zeros((ntrials, nbins))
-                for k in range(ntrials):
-                    theta_phase = phase[k]
-                    for l in range(len(pbins)-1):
-                        pl = pbins[l]
-                        pr = pbins[l+1]                   
-                        indices=(theta_phase>=pl) & (theta_phase<pr)  
-                        amplitude[k,l] = np.mean(surrogate[k][indices]) 
-
-                amplitude = np.concatenate(amplitude, axis=0)
-                pi = amplitude/np.sum(amplitude)
-                entropy = -np.sum(pi*np.log(pi))
-                modulation_index = (entropy_max-entropy)/entropy_max
-                mi[s,j] = modulation_index
-
-    return ftheta, fgamma, mi, mi_surrogates
-
-#####################################################################################################
 def compute_c_function(xseq, yseq): 
     a = np.sum( xseq*np.conj(yseq), axis=0 )
     b = np.sum( np.abs(xseq)**2, axis=0)
@@ -467,9 +290,126 @@ def brownian_noise(f):
 def pink_noise(f):
     return 1/np.where(f == 0, float('inf'), np.sqrt(f))
 
+
 ################################################################
 ## Con nuevos filtros ##
 ################################################################
+from scipy import signal
+def round_up_to_odd(f):
+    f = int(np.ceil(f))
+    return f + 1 if f % 2 == 0 else f
+def eegfilt(data,srate,locutoff,hicutoff,epochframes=0,filtorder=0,revfilt=0,firtype="firls",causal=0):
+    
+    frames = len(data)
+    nyq            = srate*0.5;  # Nyquist frequency
+    MINFREQ = 0;
+
+    minfac         = 3
+    min_filtorder  = 15
+    trans          = 0.15
+
+    if locutoff > 0 and hicutoff > 0 and locutoff > hicutoff:
+        raise ValueError('locutoff > hicutoff ???')
+
+    if locutoff < 0 or hicutoff < 0:
+        raise ValueError('locutoff | hicutoff < 0 ???')
+
+    if locutoff > nyq:
+        raise ValueError('Low cutoff frequency cannot be > srate/2')
+
+    if hicutoff > nyq:
+        raise ValueError('High cutoff frequency cannot be > srate/2')
+
+    if filtorder == 0:
+        if locutoff > 0:
+            filtorder = minfac * int(srate / locutoff)
+            filtorder=round_up_to_odd(filtorder)
+        elif hicutoff > 0:
+            filtorder = minfac * int(srate / hicutoff)
+            filtorder=round_up_to_odd(filtorder)
+        min_filtorder = 15  # Define min_filtorder if it's not defined previously
+        if filtorder < min_filtorder:
+            filtorder = min_filtorder
+            filtorder=round_up_to_odd(filtorder)
+
+    if epochframes == 0:
+        epochframes = frames  # default
+
+    epochs = frames // epochframes
+
+    if epochs * epochframes != frames:
+        raise ValueError('epochframes does not divide frames.')
+
+    if filtorder * 3 > epochframes:  # MATLAB filtfilt() restriction
+        print(f'eegfilt(): filter order is {filtorder}.')
+        raise ValueError('epochframes must be at least 3 times the filtorder.')
+
+    if (1 + trans) * hicutoff / nyq > 1:
+        raise ValueError('high cutoff frequency too close to Nyquist frequency')
+
+    if locutoff > 0 and hicutoff > 0:  # bandpass filter
+        if revfilt:
+            # print("eegfilt() - performing {}-point notch filtering.".format(filtorder))
+            pass
+        else:
+            # print("eegfilt() - performing {}-point bandpass filtering.".format(filtorder))
+            pass
+        # print("If a message, 'Matrix is close to singular or badly scaled,' appears,")
+        # print("then MATLAB has failed to design a good filter. As a workaround,")
+        # print("for band-pass filtering, first highpass the data, then lowpass it.")
+
+        if firtype == 'firls':
+            f = [MINFREQ, (1 - trans) * locutoff / nyq, locutoff / nyq, hicutoff / nyq, (1 + trans) * hicutoff / nyq, 1]
+            # print("eegfilt() - low transition band width is {:.1f} Hz; high trans. band width, {:.1f} Hz.".format((f[2] - f[1]) * srate / 2, (f[4] - f[3]) * srate / 2))
+            m = [0, 0, 1, 1, 0, 0]
+        elif firtype == 'fir1':
+            from scipy.signal import fir1
+            filtwts = fir1(filtorder, [locutoff, hicutoff] / (srate / 2))
+    elif locutoff > 0:  # highpass filter
+        if locutoff / nyq < MINFREQ:
+            raise ValueError("eegfilt() - highpass cutoff freq must be > {} Hz".format(MINFREQ * nyq))
+        # print("eegfilt() - performing {}-point highpass filtering.".format(filtorder))
+        if firtype == 'firls':
+            f = [MINFREQ, locutoff * (1 - trans) / nyq, locutoff / nyq, 1]
+            # print("eegfilt() - highpass transition band width is {:.1f} Hz.".format((f[2] - f[1]) * srate / 2))
+            m = [0, 0, 1, 1]
+        elif firtype == 'fir1':
+            from scipy.signal import firwin
+            filtwts = firwin(filtorder + 1, locutoff / (srate / 2), pass_zero=False)
+    elif hicutoff > 0:  # lowpass filter
+        if hicutoff / nyq < MINFREQ:
+            raise ValueError("eegfilt() - lowpass cutoff freq must be > {} Hz".format(MINFREQ * nyq))
+        # print("eegfilt() - performing {}-point lowpass filtering.".format(filtorder))
+        if firtype == 'firls':
+            f = [MINFREQ, hicutoff / nyq, hicutoff * (1 + trans) / nyq, 1]
+            # print("eegfilt() - lowpass transition band width is {:.1f} Hz.".format((f[2] - f[1]) * srate / 2))
+            m = [1, 1, 0, 0]
+        elif firtype == 'fir1':
+            from scipy.signal import firwin
+            filtwts = firwin(filtorder + 1, hicutoff / (srate / 2))
+    else:
+        raise ValueError('You must provide a non-0 low or high cut-off frequency')
+
+
+    if revfilt:
+        if firtype == 'fir1':
+            raise ValueError("Cannot reverse filter using 'fir1' option")
+        else:
+            m = [not x for x in m]
+    print(f,m)
+    if firtype == 'firls':
+        from scipy.signal import firls
+        filtwts = firls(filtorder, f, m)
+
+    smoothdata = np.zeros(frames)
+    print(epochframes)
+    for e in range(epochs):  # Filter each epoch, channel
+        if causal:
+            smoothdata[ (e) * epochframes:(e+1) * epochframes] = signal.lfilter(filtwts, 1, data[(e ) * epochframes:(e+1) * epochframes])
+        else:
+            smoothdata[ (e) * epochframes:(e+1) * epochframes] = signal.filtfilt(filtwts, 1, data[(e) * epochframes:(e+1) * epochframes])
+    
+    return smoothdata 
 
 def bandpass_filter(xs, norder, f_range, fs=1e4): 
     sos = scipy.signal.butter(N=norder, Wn=f_range, btype="bandpass", fs=fs, output="sos")
@@ -522,6 +462,22 @@ def bandpass_filter_and_hilbert_transform(sig, fs, f0, df, norder):
     phase, envelope= hilbert_phase(sig_band)
     return sig_band+scale, envelope+scale,  phase
 
+def bandpass_filter_and_hilbert_transform2(sig, fs, f0, df, norder):
+    scale = sig.mean() 
+    f_range = (f0-df, f0+df)
+    sig_band = bandpass_filter(sig, norder, f_range, fs)
+    phase, envelope= hilbert_phase(sig_band)
+    return sig_band+scale, envelope,  phase
+
+def bandpass_filter_and_hilbert_transform3(sig, fs, f0, df, norder):
+    scale = sig.mean() 
+    f_range = (f0-df, f0+df)
+    print(f_range)
+    sig_band = eegfilt(sig, fs, f_range[0],f_range[-1])
+    phase, envelope= hilbert_phase(sig_band)
+    
+    return sig_band+scale, envelope,  phase
+
 def get_nfft(m):
     nfft = 2
     k = 0 
@@ -533,8 +489,8 @@ def get_nfft(m):
 def surrogate_generation(timeseries, nsurrogates, method ="block boostrapping" , replace = False, nsplits = 99): 
     surrogate_list = [] 
     n = len(timeseries)
-
-    if method == "2block boostraping":
+    
+    if method == "2block boostrapping":
         for _ in range(nsurrogates):
             ir = np.random.randint(low=0,high=len(timeseries))
             surrogate = np.array( list(timeseries[ir:])+list(timeseries[:ir]) )
@@ -546,23 +502,13 @@ def surrogate_generation(timeseries, nsurrogates, method ="block boostrapping" ,
             surrogate_list.append( surrogate )
     
     if method == "fourier":
-        # for _ in range(nsurrogates):
-        #     fourier = np.fft.fft(timeseries)
-        #     random_phases = 1j*np.random.choice(fourier.imag[:n//2], size=n//2, replace=replace)
-        #     random_phases = np.concatenate(( random_phases, random_phases[::-1] ))
-        #     fourier_new = fourier*random_phases
-        #     surrogate = np.real( np.fft.ifft(fourier_new))
-        #     surrogate_list.append( surrogate )
-        
         for _ in range(nsurrogates):
-            fourier = np.fft.rfft(timeseries)
-            amplitude, phases= np.abs(fourier), np.angle(fourier)
-            new_phases = copy.copy(phases)
-            np.random.shuffle( new_phases )
-            fourier_new = amplitude*new_phases
+            fourier = np.fft.fft(timeseries)
+            random_phases = 1j*np.random.choice(fourier.imag[:n//2], size=n//2, replace=replace)
+            random_phases = np.concatenate(( random_phases, random_phases[::-1] ))
+            fourier_new = fourier*random_phases
             surrogate = np.real( np.fft.ifft(fourier_new))
             surrogate_list.append( surrogate )
-
             
     if method == "block boostrapping":
         timeseries_splitted = np.array( np.array_split(timeseries, nsplits) ) 
@@ -574,83 +520,29 @@ def surrogate_generation(timeseries, nsurrogates, method ="block boostrapping" ,
             
     return surrogate_list 
 
-def surrogate_generation_list(timeseries, nsurrogates, method ="block boostrapping" , replace = False, nsplits = 99): 
-    '''
-    now timeseries is a list
-    '''
-    ntrials, n = np.shape( timeseries )
-    surrogate_list = [ [] for k in range(ntrials) ] 
-
-    if method == "2block boostraping":
-        for k in range(ntrials):
-            for _ in range(nsurrogates):
-                ir = np.random.randint(low=0,high=len(timeseries[k]))
-                surrogate = np.array( list(timeseries[k][ir:])+list(timeseries[k][:ir]) )
-                surrogate_list[k].append( surrogate )
-            
-    if method == "sampling":
-        for k in range(ntrials):
-            for _ in range(nsurrogates):
-                surrogate = np.random.choice(timeseries[k], size=n, replace=replace)
-                surrogate_list[k].append( surrogate )
-        
-    if method == "fourier":
-        for k in range(ntrials):
-            for _ in range(nsurrogates):
-                fourier = np.fft.rfft(timeseries[k])
-                amplitude, phases= np.abs(fourier), np.angle(fourier)
-                new_phases = copy.copy(phases)
-                np.random.shuffle( new_phases )
-                fourier_new = amplitude*new_phases
-                surrogate = np.real( np.fft.ifft(fourier_new))
-                surrogate_list[k].append( surrogate )
-
-            
-    if method == "block boostrapping":
-        for k in range(ntrials):
-            timeseries_splitted = np.array( np.array_split(timeseries[k], nsplits) ) 
-            ns = len(timeseries_splitted)
-            for _ in range(nsurrogates):
-                indexes_surrogate = np.random.choice( np.arange(ns), size = ns, replace=replace)
-                surrogate = np.concatenate( timeseries_splitted[indexes_surrogate] )
-                surrogate_list[k].append( surrogate )
-                
-    return np.array(surrogate_list).T # (nsurrogates, ntrials)
-
 def get_pvalue( samples,  popmean, method = "two-sided"):
-    z0 = (popmean-samples.mean())/samples.std()
+    z0 = (popmean-samples.mean(0))/samples.std(0)
     if method == "two-sided":
         pvalue = scipy.stats.norm.sf(abs(z0))*2
     if method == "one-sided":
         pvalue = scipy.stats.norm.sf(abs(z0))
     return pvalue
 
-def get_statistical_significance( samples, popmean, method = "two-sided"):
-    
-    if method == "two-sided":
-        q1 = np.quantile( samples, 0.975, axis=0)
-        q2 = np.quantile( samples, 0.025, axis=0)
-        condition = np.logical_or( popmean >= q1, popmean <= q2)
-        
-    if method == "one-sided":
-        q = np.quantile( samples , 0.95, axis = 0) # right
-        condition = (popmean >= q)
-    return condition
-
 #################################################################################################
-def compute_coherence_measurements(x, fs, nperseg, noverlap, ftheta_min=4, ftheta_max=20, fgamma_min=25, fgamma_max=100, dfgamma=2,
-                                   norder=4, nfft=2048, surrogate_test=True, nsurrogates=100, surrogate_method = "block boostrapping", surrogate_nsplits=99):
+def compute_coherence_measurements(x, fs, nperseg, noverlap, ftheta_min=4, ftheta_max=20, fgamma_min=25, fgamma_max=100, dfgamma=2,Filter_gamma=10,
+                                   norder=4, nfft=2048,surrogate_test=True, nsurrogates=100,choiseSurr = 0):
     
     psi, nu = [],[] 
     psi_surrogates = [ [] for i in range(nsurrogates) ]
     nu_surrogates  = [ [] for i in range(nsurrogates) ]
     
     fgamma = np.arange(fgamma_min,fgamma_max,dfgamma)
+    #scipy.signal.csd: cross power spectral density 
     fr, pxx  = scipy.signal.csd( x, x, fs=fs, window="hann", nfft=nfft, nperseg=nperseg, noverlap = noverlap)
     
     np.random.seed(12)
     for fg in fgamma:
-        yf, y, _ = bandpass_filter_and_hilbert_transform(x, norder=norder, fs=fs, f0=fg, df=10)
+        _, y, _ = bandpass_filter_and_hilbert_transform3(x, norder=norder, fs=fs, f0=fg, df=Filter_gamma)
         fr, pyy  = scipy.signal.csd( y, y, fs=fs, window="hann", nfft=nfft, nperseg=nperseg, noverlap = noverlap)
         fr, pxy  = scipy.signal.csd( y, x, fs=fs, window="hann", nfft=nfft, nperseg=nperseg, noverlap = noverlap) 
         complex_coherence = pxy / np.sqrt( np.abs(pxx)*np.abs(pyy) ) 
@@ -675,10 +567,15 @@ def compute_coherence_measurements(x, fs, nperseg, noverlap, ftheta_min=4, fthet
         psi.append( np.array( cfd ) )
         nu.append( np.abs( complex_coherence[imin:imax] ) ) 
 
-        if surrogate_test: 
-            surrogates = surrogate_generation( y, nsurrogates = nsurrogates, method=surrogate_method, nsplits = surrogate_nsplits)
+        if surrogate_test:
+            if(choiseSurr==0):
+                surrogates = surrogate_generation( x, nsurrogates = nsurrogates)
+            elif(choiseSurr==1):
+                surrogates = surrogate_generation( x, nsurrogates = nsurrogates,nsplits=int(len(x)/nperseg))
+            elif(choiseSurr==2):
+                surrogates = surrogate_generation( x, nsurrogates = nsurrogates,method="2block boostrapping")
             for l, surrogate in enumerate(surrogates): 
-                yf, y, _ = bandpass_filter_and_hilbert_transform(surrogate, norder=norder, fs=fs, f0=fg, df=10)
+                yf, y, _ = bandpass_filter_and_hilbert_transform3(surrogate, norder=norder, fs=fs, f0=fg, df=10)
                 
                 fr, pyy  = scipy.signal.csd( y, y, fs=fs, window="hann", nfft=nfft, nperseg=nperseg, noverlap = noverlap)
                 fr, pxy  = scipy.signal.csd( y, x, fs=fs, window="hann", nfft=nfft, nperseg=nperseg, noverlap = noverlap) 
@@ -703,19 +600,17 @@ def compute_coherence_measurements(x, fs, nperseg, noverlap, ftheta_min=4, fthet
                 ####################################################################################
                 psi_surrogates[l].append( np.array(cfd) )
                 nu_surrogates[l].append( np.abs(complex_coherence[imin:imax]) )
-    
-    psi_surrogates = np.array(psi_surrogates) 
-    nu_surrogates = np.array(nu_surrogates) 
+                
     ftheta = fr[imin:imax]
     return ftheta, fgamma, psi, nu, psi_surrogates, nu_surrogates
 
 #################################################################################################
     
-def gamma_theta_phase_coupling( theta_phase, gamma_envelope, surrogate_test=True, nsurrogates=100, 
-                              surrogate_method =  "block boostrapping"):
+def gamma_theta_phase_coupling( theta_phase, gamma_envelope, surrogate_test=True, nsurrogates=100 ):
     
     height = []
     amplitude = [] 
+    amplitude_error = [] 
     surrogates = []
     height_surrogates = []
     amplitude_surrogates = []
@@ -725,23 +620,27 @@ def gamma_theta_phase_coupling( theta_phase, gamma_envelope, surrogate_test=True
     pbins = np.linspace(0,2*np.pi,nbins+1)
     for phi, amp in zip(theta_phase, gamma_envelope): 
         a_mean = np.zeros(len(pbins)-1)       
+        a_err  = np.zeros(len(pbins)-1)
         p_mean = np.zeros(len(pbins)-1)       
         for k in range(len(pbins)-1):         
             pl = pbins[k]                     
             pr = pbins[k+1]                   
             indices=(phi>=pl) & (phi<pr)      
             a_mean[k] = np.mean(amp[indices])  
-            p_mean[k] = np.mean([pL, pR]) 
+            a_err[k]  = np.std(amp[indices])/np.sqrt(len(amp[indices]))
+            p_mean[k] = np.mean([pl, pr]) 
             
         height.append( np.max(a_mean)-np.min(a_mean) )
         amplitude.append( a_mean )
+        amplitude_error.append( a_err ) 
+        
         
         if surrogate_test:
             surrogates.append( [] )
             height_surrogates.append( [] )
             amplitude_surrogates.append( [] )
 
-            surrogates = surrogate_generation( timeseries=amp, nsurrogates=nsurrogates, method = surrogate_method)
+            surrogates = surrogate_generation( timeseries=amp, nsurrogates=nsurrogates, method = "block boostrapping")
             
             for ii, surrogate in enumerate(surrogates):
                 amean = np.zeros(len(pbins)-1)      
@@ -751,10 +650,10 @@ def gamma_theta_phase_coupling( theta_phase, gamma_envelope, surrogate_test=True
                     pr = pbins[k+1]                   
                     indices=(phi>=pl) & (phi<pr)      
                     a_mean[k] = np.mean(surrogate[indices])  
-                    p_mean[k] = np.mean([pL, pR]) 
+                    p_mean[k] = np.mean([pl, pr]) 
 
                 height_surrogates[-1].append( np.max(a_mean)-np.min(a_mean) )
                 amplitude_surrogates[-1].append( a_mean )
                 
-    return amplitude, height, ampltiude_surrogates, height_surrogates, surrogates 
+    return amplitude, amplitude_error, p_mean, height, amplitude_surrogates, height_surrogates, surrogates 
 


### PR DESCRIPTION
I have translated eegfilt() function from matlab to python. There is still some differences since scipy.signal.firls is slightly different than firls of Matlab (the first one needs an odd number for the first argument, while the latter it does not). Thus the results could be slightly different. Nonetheless, now the CFC is much closer to Victor's than with the previous filter.  The new filtering function is being used in bandpass_filter_and_hilbert_transform3(), bandpass_filter_and_hilbert_transform2() is the previous version. 